### PR TITLE
fix(Dockerfile): Golang container image digest

### DIFF
--- a/.github/workflows/check-changes.yaml
+++ b/.github/workflows/check-changes.yaml
@@ -9,6 +9,9 @@ on:
       deps:
         description: Dependencies changed
         value: ${{ jobs.paths-filter.outputs.deps }}
+      container:
+        description: Container changed
+        value: ${{ jobs.paths-filter.outputs.container }}
 
 jobs:
   paths-filter:
@@ -17,6 +20,7 @@ jobs:
     outputs:
       go: ${{ steps.changes.outputs.go }}
       deps: ${{ steps.changes.outputs.deps }}
+      container: ${{ steps.changes.outputs.container }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,6 +30,8 @@ jobs:
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
+            container:
+              - Dockerfile
             go:
               - '*.go'
               - 'go.mod'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     needs: ["check-changes"]
-    if: ${{ needs.check-changes.outputs.go == 'true' }}
+    if: ${{ needs.check-changes.outputs.go == 'true' || needs.check-changes.outputs.container == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.26.5-bookworm@sha256:eb37f58646a901dc7727cf448cae36daaefaba79de33b5058dab79aa4c04aefb AS build
+FROM docker.io/golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651 AS build
 WORKDIR /src
 
 COPY go.mod go.sum ./


### PR DESCRIPTION
Dockerfile contained an invalid digest for the golang image.
Run integration tests on container image changes to prevent invalid digests from being merged.